### PR TITLE
Unload Profile Edit form on User Display Switch

### DIFF
--- a/eros/components/Sidebar.tsx
+++ b/eros/components/Sidebar.tsx
@@ -155,6 +155,11 @@ const Sidebar = ({ hardEdge }: sidebarProps) => {
 				}
 				//update to change the profile shown without link change
 				setSideProf(e.detail);
+				//we just switched to showing a different user's profile,
+				//(possibly with our profile's edit form still open), so
+				//remove the edit form and show that user's data normally
+				setShowEditForm(false);
+				//*yes, the 2 above both rerender, but both are still run!
 			}
 		};
 		setTimeout(() => {


### PR DESCRIPTION
### 📜 Purpose
This is a simple solution for when the edit form persisted and was repopulated with another user's data after clicking on them in your following list. This odd phenomenon was reported in an issue. This pr fixes #45.

### 🎯 New
- [x] Reset `showEditForm` state after every non-reloaded change of the profile display in the sidebar 